### PR TITLE
Add support for glslangValidator compound extensions

### DIFF
--- a/src/features/glsllintProvider.ts
+++ b/src/features/glsllintProvider.ts
@@ -198,11 +198,11 @@ export class GLSLLintingProvider {
       '.task': 'task', // for a task shader
     };
 
-    // glslangValidator supports compound extensions now that it supports multiple 
+    // glslangValidator supports compound extensions now that it supports multiple
     // shader languages:
     // .glsl   for .vert.glsl, .tesc.glsl, ..., .comp.glsl compound suffixes
     // .hlsl   for .vert.hlsl, .tesc.hlsl, ..., .comp.hlsl compound suffixes
-    if (fileName.endsWith(".glsl") || fileName.endsWith(".hlsl")) {
+    if (fileName.endsWith('.glsl') || fileName.endsWith('.hlsl')) {
       fileName = fileName.slice(0, -5) ;  
     }
 

--- a/src/features/glsllintProvider.ts
+++ b/src/features/glsllintProvider.ts
@@ -198,6 +198,14 @@ export class GLSLLintingProvider {
       '.task': 'task', // for a task shader
     };
 
+    // glslangValidator supports compound extensions now that it supports multiple 
+    // shader languages:
+    // .glsl   for .vert.glsl, .tesc.glsl, ..., .comp.glsl compound suffixes
+    // .hlsl   for .vert.hlsl, .tesc.hlsl, ..., .comp.hlsl compound suffixes
+    if (fileName.endsWith(".glsl") || fileName.endsWith(".hlsl")) {
+      fileName = fileName.slice(0, -5) ;  
+    }
+
     const additionalStageMappings = this.config.additionalStageAssociations;
     const mergedStageMappings = { ...stageMapping, ...additionalStageMappings };
 

--- a/test/test_shaders/SOME_FILE_EXTENSIONS/pass_through.frag.glsl
+++ b/test/test_shaders/SOME_FILE_EXTENSIONS/pass_through.frag.glsl
@@ -1,0 +1,10 @@
+precision highp float;
+
+// input from vertex shader
+varying vec3 vColor;
+
+
+void main()
+{
+  gl_FragColor = vec4(vec3(vColor), 1.0);
+}

--- a/test/test_shaders/SOME_FILE_EXTENSIONS/pass_through.vert.glsl
+++ b/test/test_shaders/SOME_FILE_EXTENSIONS/pass_through.vert.glsl
@@ -1,0 +1,12 @@
+uniform mat4 u_projectionMatrix;
+uniform mat4 u_viewMatrix;
+uniform mat4 u_modelMatrix;
+
+attribute vec3 a_position;
+
+varying vec4 v_color;
+
+void main() {
+  v_color = vec4(1.0, 0.0, 0.0, 1.0);
+  gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * vec4( a_position, 1.0 );
+}


### PR DESCRIPTION
`glslangValidor` now supports GLSL and HLSL. It allows language detection by suffixing with the language. Currently naming a file as `stage.lang` errors.