### PR TITLE
Added .raytrace extension to supported formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
           ".rchit",
           ".rmiss",
           ".rcall",
+          ".raytrace",
           ".mesh",
           ".task"
         ]


### PR DESCRIPTION
While developing in Unity (maybe in pure C++and CUDA too) main ray tracing shader has .raytrace extension