### PR TITLE
error-column matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "vscode-glsllint" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.9.1]
+
+### Added
+
+- Since https://github.com/KhronosGroup/glslang/pull/3614, glslangValidator now outputs the error column as well. If `--error-column` is given among `glslangValidatorArgs`, then glsllint will display glsl errors under the correct column, not just at the start of the line
+
 ## [1.9.x]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-glsllint",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "publisher": "dtoplak",
   "repository": {
     "type": "git",

--- a/src/features/glsllintProvider.ts
+++ b/src/features/glsllintProvider.ts
@@ -526,13 +526,27 @@ export class GLSLLintingProvider {
               }
 
               if (severity !== undefined) {
-                const matches = line.match(/(WARNING|ERROR):\s+(\d|.*):(\d+):\s+(.*)/);
-                if (matches && matches.length === 5) {
-                  const errorline = parseInt(matches[3]);
-                  const message = matches[4];
-                  const range = new vscode.Range(errorline - 1, 0, errorline - 1, 0);
-                  const diagnostic = new vscode.Diagnostic(range, message, severity);
-                  diagnostics.push(diagnostic);
+                /* If arguments include the new --error-column change the regex */
+                if (args.includes('--error-column')) {
+                  const matches = line.match(/(WARNING|ERROR):\s+(\d|.*):(\d+):(\d+):\s+(.*)/);
+                  if (matches && matches.length === 6) {
+                    const errorline = parseInt(matches[3]);
+                    const errorcolumn = parseInt(matches[4]);
+                    const message = matches[5];
+                    const range = new vscode.Range(errorline - 1, errorcolumn, errorline - 1, errorcolumn);
+                    const diagnostic = new vscode.Diagnostic(range, message, severity);
+                    diagnostics.push(diagnostic);
+                  }
+                } else {
+                  /* The previous case without error-column */
+                  const matches = line.match(/(WARNING|ERROR):\s+(\d|.*):(\d+):\s+(.*)/);
+                  if (matches && matches.length === 5) {
+                    const errorline = parseInt(matches[3]);
+                    const message = matches[4];
+                    const range = new vscode.Range(errorline - 1, 0, errorline - 1, 0);
+                    const diagnostic = new vscode.Diagnostic(range, message, severity);
+                    diagnostics.push(diagnostic);
+                  }
                 }
               }
             }


### PR DESCRIPTION
Thanks to @antaalt and his https://github.com/KhronosGroup/glslang/pull/3614, we now have the error column reported by `glslangValidator`. This Pull Request adds compatibility for this.

| Before this PR (or without `--error-column`) | This PR |
|------------------------------------|---------|
| ![image](https://github.com/user-attachments/assets/149eb10b-7d77-44f9-9af2-eb3886285ead) | ![image](https://github.com/user-attachments/assets/a1ac81be-a2f6-408b-a370-2ee737c0cb03) |

# Functionality
If you have updated `glslangValidator` to a version that supports this, you can specify `"--error-column` among `"glsllint.glslangValidatorArgs`. Like this: `"glsllint.glslangValidatorArgs": ["--error-column"]`

Since there is no official release version yet, nightly builds of `glslangValidator` can be had here: https://github.com/KhronosGroup/glslang/releases/tag/main-tot

If `--error-column` is among the arguments, a new regex is used to pull the column and display the error squiggly accordingly.